### PR TITLE
Add soem comments and bot activity as param

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -19,7 +19,7 @@ impl EventHandler for Handler {
     async fn ready(&self, context: Context, _ready: serenity::model::gateway::Ready) {
         info!("discord bot is ready");
         context.online().await;
-        context.set_activity(Activity::playing("THIS IS A TEST")).await;
+        context.set_activity(Activity::playing("stdinman")).await; // TODO: Also accept this as config / cli param?
 
         let cache_clone = context.cache.clone();
         let context_clone = context.clone();
@@ -48,6 +48,9 @@ impl EventHandler for Handler {
 
             info!("joined channel sucessfully!");
             debug!("Telling early-stdin consumer to stop...");
+            // This will send a signal to the thread which is "wasting" stdin while we took time to
+            // connect to discord, which will then allow this guy to consume the data (audio) on stdin
+            // and play it via the bot
             self.tx.lock().expect("fail to acquire lock on early-stdin consumer").send(true).expect("fail to signal early-stdin consumer");
 
             // Now we have access to stdin

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -11,6 +11,7 @@ use super::stdin;
 
 pub struct Handler {
     pub voice_channel_id: String,
+    pub bot_activity: String,
     pub tx: Mutex<mpsc::Sender<bool>>
 }
 
@@ -19,7 +20,7 @@ impl EventHandler for Handler {
     async fn ready(&self, context: Context, _ready: serenity::model::gateway::Ready) {
         info!("discord bot is ready");
         context.online().await;
-        context.set_activity(Activity::playing("stdinman")).await; // TODO: Also accept this as config / cli param?
+        context.set_activity(Activity::playing(self.bot_activity.clone())).await;
 
         let cache_clone = context.cache.clone();
         let context_clone = context.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,10 @@ async fn main() {
 
     let (tx, rx) = mpsc::channel::<bool>();
 
+    // As soon as stdinman is started, data will start to get piped to it (e.g. from ffmpeg)
+    // But it'll take some time to actually connect to discord and the voice channel 
+    // (3-5s in practice). To avoid these 3-5s of audio getting buffered and then causing some weird
+    // behavior, we create a "dummy" stdin consumer, which reads from stdin and just discards the data
     debug!("starting early-stdin consumer thread");
     thread::spawn(|| stdin::early_stdin_consumer(rx));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::thread;
+use std::{default, thread};
 
 use log::{error, debug};
 use songbird::SerenityInit;
@@ -14,9 +14,11 @@ mod discord;
 
 
 #[derive(Default, Serialize, Deserialize)]
+#[serde(default)] // we need this if we add new fields, otherwise confy will throw error on load (https://github.com/rust-cli/confy/issues/34)
 struct StdinmanConfig {
     bot_token: String,
     voice_channel_id: String,
+    bot_activity: String
 }
 
 #[derive(Parser)]
@@ -24,7 +26,9 @@ struct StdinmanArgs {
     #[arg(long)]
     bot_token: Option<String>,
     #[arg(long)]
-    voice_channel_id: Option<String>
+    voice_channel_id: Option<String>,
+    #[arg(long)]
+    bot_activity: Option<String>,
 }
 
 #[tokio::main]
@@ -67,6 +71,17 @@ async fn main() {
         }
     };
 
+    let bot_activity = match args.bot_activity {
+        Some(activity) => activity,
+        None => {
+            if cfg.bot_activity == "" {
+                String::from("stdinman")
+            } else {
+                cfg.bot_activity
+            }
+        }
+    };
+
     let (tx, rx) = mpsc::channel::<bool>();
 
     // As soon as stdinman is started, data will start to get piped to it (e.g. from ffmpeg)
@@ -82,6 +97,7 @@ async fn main() {
         .register_songbird()
         .event_handler(discord::Handler{ 
             voice_channel_id: voice_channel_id,
+            bot_activity: bot_activity,
             tx: tx.into(),
         })
         .framework(framework)


### PR DESCRIPTION
Make code a bit more readable, especially with the early stdin consumer thingy.